### PR TITLE
Add ignore feature

### DIFF
--- a/cmd/vault-import/main.go
+++ b/cmd/vault-import/main.go
@@ -20,6 +20,21 @@ const (
 
 var (
 	cfgFile string
+	rootCmd *cobra.Command
+
+	// Brute global var
+	Brute bool
+	// Verbose global var
+	Verbose bool
+)
+
+func exitErr(e error) {
+	log.SetOutput(os.Stderr)
+	log.Println(e)
+	os.Exit(1)
+}
+
+func init() {
 	rootCmd = &cobra.Command{
 		Use:   "vault-import",
 		Short: "import secrets to Vault",
@@ -73,26 +88,7 @@ var (
 			return nil
 		},
 	}
-	// Brute global var
-	Brute bool
-	// Verbose global var
-	Verbose bool
-)
 
-func exitErr(e error) {
-	log.SetOutput(os.Stderr)
-	log.Println(e)
-	os.Exit(1)
-}
-
-func logSetup() {
-	log.SetFlags(0)
-	if Verbose {
-		log.SetFlags(log.LstdFlags | log.Lshortfile)
-	}
-}
-
-func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is ./config.yaml)")
@@ -123,6 +119,13 @@ func initConfig() {
 	viper.SetEnvPrefix("VAULT_IMPORT")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 	viper.AutomaticEnv()
+}
+
+func logSetup() {
+	log.SetFlags(0)
+	if Verbose {
+		log.SetFlags(log.LstdFlags | log.Lshortfile)
+	}
 }
 
 func main() {

--- a/cmd/vault-import/main.go
+++ b/cmd/vault-import/main.go
@@ -14,8 +14,10 @@ import (
 )
 
 const (
-	vaFlag = "vault-addr"
-	vtFlag = "vault-token"
+	vaFlag          = "vault-addr"
+	vtFlag          = "vault-token"
+	ignoreKeysFlag  = "ignore-keys"
+	ignorePathsFlag = "ignore-paths"
 )
 
 var (
@@ -67,7 +69,12 @@ func init() {
 				Address: viper.GetString(vaFlag),
 				Retries: retries,
 				Token:   viper.GetString(vtFlag),
+				Ignore: &vault.Ignore{
+					Keys:  viper.GetStringSlice(ignoreKeysFlag),
+					Paths: viper.GetStringSlice(ignorePathsFlag),
+				},
 			})
+
 			if err != nil {
 				return err
 			}
@@ -94,9 +101,14 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is ./config.yaml)")
 	rootCmd.PersistentFlags().String(vaFlag, "https://127.0.0.1:8200", "vault url")
 	rootCmd.PersistentFlags().String(vtFlag, "", "vault token")
+	rootCmd.PersistentFlags().StringSlice(ignoreKeysFlag, []string{}, "comma separated list of key names to ignore")
+	rootCmd.PersistentFlags().StringSlice(ignorePathsFlag, []string{}, "comma separated list of paths to ignore")
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&Brute, "brute", "", false, "retry failed indefinitely")
 	rootCmd.Flags().ParseErrorsWhitelist.UnknownFlags = true
+
+	viper.BindPFlag(ignoreKeysFlag, rootCmd.PersistentFlags().Lookup(ignoreKeysFlag))
+	viper.BindPFlag(ignorePathsFlag, rootCmd.PersistentFlags().Lookup(ignorePathsFlag))
 }
 
 func initConfig() {

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -147,10 +147,27 @@ func (c *Config) secretProducer(ctx context.Context, secrets map[string]interfac
 			close(secretChan)
 			return
 		default:
-			secretChan <- map[string]interface{}{
-				"k": p,
-				"v": s,
+			qualified := true
+			for _, ip := range c.VaultConfig.Ignore.Paths {
+				if strings.HasPrefix(p, ip) {
+					qualified = false
+					break
+				}
 			}
+			for _, ik := range c.VaultConfig.Ignore.Keys {
+				if strings.HasSuffix(p, ik) {
+					qualified = false
+					break
+				}
+			}
+
+			if qualified {
+				secretChan <- map[string]interface{}{
+					"k": p,
+					"v": s,
+				}
+			}
+
 		}
 	}
 

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -17,7 +17,14 @@ type Config struct {
 	Token   string
 	Client  *vaultapi.Client
 	Retries int
+	Ignore  *Ignore
 	memo    *sync.Map
+}
+
+// Ignore
+type Ignore struct {
+	Keys  []string
+	Paths []string
 }
 
 // NewClient


### PR DESCRIPTION
This adds the ability to modify the secrets to import by providing paths or keys, think prefixes and suffixes, via the `--ignore-keys` and `--ignore-paths` command line flags