### PR TITLE
Remap database config connection details during import

### DIFF
--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -19,6 +19,7 @@ const (
 	bufsize = 1000
 )
 
+var VaultDatabaseConfigPrefix = []string{"/database/config/"}
 var VaultPolicyPrefix = []string{"/sys/policy/"}
 var VaultPolicyProtected = []string{"/sys/policy/default", "/sys/policy/root"}
 
@@ -246,6 +247,15 @@ func (vc *Config) PurgePaths(paths []string) error {
 	return nil
 }
 
+// IsDatabaseConfig
+func IsDatabaseConfig(key string) bool {
+	for _, prefix := range VaultDatabaseConfigPrefix {
+		if strings.HasPrefix(key, EnsureNoTrailingSlash(prefix)) {
+			return true
+		}
+	}
+	return false
+}
 // IsPolicy
 func IsPolicy(key string) bool {
 	for _, prefix := range VaultPolicyPrefix {


### PR DESCRIPTION
Database config imports are currently failing due to a mismatch between the vault API's read and write formats.

This PR filters for keys with a database config prefix, and transforms them prior to import.